### PR TITLE
Feature/#13 deno emitからesbuildに移行

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,10 +3,12 @@
     "@deno/emit": "jsr:@deno/emit@^0.46.0",
     "@std/http": "jsr:@std/http@^1.0.17",
     "leaflet": "npm:leaflet@^1.9.4",
-    "egmap": "./lib/egmap.ts"
+    "egmap": "./lib/egmap.ts",
+    "@deno/esbuild-plugin": "jsr:@deno/esbuild-plugin@^1.2.0",
+    "esbuild": "npm:esbuild@^0.25.9"
   },
   "tasks": {
-    "start": "deno run --watch --allow-net --allow-read main.ts"
+    "start": "deno run --watch --allow-net --allow-read  --allow-run --allow-env main.ts"
   },
   "compilerOptions": {
     "lib": [

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,8 @@
 {
   "imports": {
     "@deno/emit": "jsr:@deno/emit@^0.46.0",
-    "@std/http": "jsr:@std/http@^1.0.17"
+    "@std/http": "jsr:@std/http@^1.0.17",
+    "leaflet": "npm:leaflet@^1.9.4"
   },
   "tasks": {
     "start": "deno run --watch --allow-net --allow-read main.ts"

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,8 @@
   "imports": {
     "@deno/emit": "jsr:@deno/emit@^0.46.0",
     "@std/http": "jsr:@std/http@^1.0.17",
-    "leaflet": "npm:leaflet@^1.9.4"
+    "leaflet": "npm:leaflet@^1.9.4",
+    "egmap": "./lib/egmap.ts"
   },
   "tasks": {
     "start": "deno run --watch --allow-net --allow-read main.ts"

--- a/lib/egmap.ts
+++ b/lib/egmap.ts
@@ -1,0 +1,128 @@
+// MIT License
+// 
+// Copyright (c) 2019 Taisuke Fukuno
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// https://code4fukui.github.io/egmapjs/egmap.js
+
+
+// @deno-types="npm:@types/leaflet" // Denoに対して、Leafletの型定義ファイルを指定します
+import L from 'npm:leaflet';
+
+// L.Mapを拡張して、iconLayerとaddIconメソッドを持つ新しいインターフェースを定義します
+export interface MapWithIconLayer extends L.Map {
+    iconLayer: L.LayerGroup; // アイコンをまとめるためのレイヤーグループ
+    addIcon: ( // マップにアイコンを追加するためのメソッド
+        lat: number, // アイコンの緯度
+        lng: number, // アイコンの経度
+        nameOrParam: { // アイコンの名前やコールバック関数を含むオブジェクト、または名前の文字列、またはコールバック関数. stringならばそれが表示されるだけだが, 関数ならクリック時に実行される.
+            name?: string; // アイコンの名前（ポップアップに表示される）
+            callback?: ((e: L.LeafletMouseEvent, name?: string) => void); // アイコンクリック時に実行されるコールバック関数
+        } | string | ((e: L.LeafletMouseEvent, name?: string) => void),
+        iconUrl?: string, // アイコン画像のURL（オプション）
+        iconWidth?: number, // アイコンの幅（オプション）
+        iconHeight?: number, // アイコンの高さ（オプション）
+    ) => L.Marker; // 追加されたマーカーオブジェクトを返す
+}
+
+// 指定されたIDのHTML要素にマップを埋め込む関数
+export const initMap = (mapid: string): MapWithIconLayer => {
+    const map = L.map(mapid) as MapWithIconLayer; // 指定されたIDの要素にLeafletマップオブジェクトを生成
+
+    // OpenStreetMapから地図タイルを取得し、マップレイヤーとして追加
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        // 地図の著作権情報を設定します
+        attribution: '© <a href="http://osm.org/copyright">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+    }).addTo(map); // 作成したタイルレイヤーをマップに追加
+
+    // アイコン関連の初期設定
+    map.iconLayer = L.layerGroup();  // アイコン用のレイヤーグループを生成
+    map.iconLayer.addTo(map);  // 生成したレイヤーをマップに追加
+    map.addIcon = (  // mapオブジェクトにaddIconメソッドを追加
+        lat, // 緯度
+        lng, // 経度
+        nameOrParam, // 名前またはパラメータオブジェクト
+        iconUrl, // アイコン画像のURL
+        iconWidth, // アイコンの幅
+        iconHeight, // アイコンの高さ
+    ) => {
+        // アイコンの名前について
+        let name = null; // アイコンの名前を格納する変数
+        // nameOrParamが文字列の場合、それを名前に設定
+        if (typeof nameOrParam == "string") {
+            name = nameOrParam;
+        // nameOrParamがオブジェクトで、nameプロパティを持つ場合、その値を名前に設定
+        } else if (typeof nameOrParam == "object" && nameOrParam.name) {
+            name = nameOrParam.name;
+        }
+        
+        let marker; // マーカーオブジェクトを格納する変数
+        // アイコンURLが指定されている場合
+        if (iconUrl) {
+            // アイコンの幅が指定されていなければデフォルトで32に設定
+            if (!iconWidth) {
+                iconWidth = 32;
+            }
+            // Leafletのiconオブジェクトをカスタム設定で生成
+            const icon = L.icon({
+                iconUrl: iconUrl, // アイコン画像のURL
+                iconSize: [iconWidth, iconHeight ?? iconWidth], // アイコンのサイズ。高さがなければ幅と同じ値を使
+                iconAnchor: [iconWidth / 2,  iconHeight ?? iconWidth / 2], // アイコンのアンカー位置（画像の中心）
+            });
+            // カスタムアイコンを使用してマーカーを生成
+            marker = L.marker([lat, lng], {
+                title: name?? undefined, // マーカーのタイトル（マウスホバーで表示）
+                icon: icon, // 上で作ったカスタムアイコン
+            });
+        } else {
+            // アイコンURLが指定されていない場合、デフォルトのマーカーを生成します
+            marker = L.marker([lat, lng], { title: name ?? undefined });
+        }
+        
+        // nameOrParamが関数の場合、それをクリックイベントのハンドラとして設定. 
+        if (typeof nameOrParam == "function") {
+            marker.on("click", function (e) {
+                // クリック時に指定されたコールバック関数を実行します
+                nameOrParam(e, name ?? undefined);
+            });
+        } else {
+            // それ以外の場合、マーカーにポップアップをバインドします
+            marker.bindPopup(
+                "<h2>" + name + "</h2>", // ポップアップに表示するHTMLコンテンツ
+                {
+                    maxWidth: 500, // ポップアップの最大幅
+                },
+            );
+            // マーカーのクリックイベントにリスナーを追加します
+            marker.on("click", function (e) {
+                // nameOrParamがコールバックを持つオブジェクトの場合、そのコールバックを実行します
+                if (nameOrParam && typeof nameOrParam === "object" && nameOrParam.callback) {
+                    nameOrParam.callback(e, name ?? undefined);
+                }
+            });
+        }
+        
+        // 生成したマーカーをアイコンレイヤーに追加
+        map.iconLayer.addLayer(marker);
+        // 生成したマーカーオブジェクトを返す
+        return marker;
+    };
+    // 初期化およびカスタマイズされたmapオブジェクトを返します
+    return map;
+};

--- a/main.ts
+++ b/main.ts
@@ -1,46 +1,50 @@
 import {serveDir} from 'jsr:@std/http/file-server';
-import console from 'node:console';
 import {join} from 'jsr:@std/path';
-import {bundle} from 'jsr:@deno/emit';
-import denoConfig from './deno.json' with {type: 'json'};
+import * as esbuild from 'esbuild';
+import {denoPlugin} from '@deno/esbuild-plugin';
 
 const publicRoot = join(Deno.cwd(), 'public');
 
 Deno.serve(async (req) => {
 	const pathname = new URL(req.url).pathname;
-	console.log(pathname);
 
-	// .tsをトランスパイルするブロック
-	if (pathname.endsWith('.ts')) { // URLの末尾が.tsなら
-		const tsPath = join(publicRoot, pathname); // public/<ファイルパス>を得る
+	// .tsをバンドルしてjsに変換するブロック
+	if (pathname.endsWith('.ts')) {
+		const tsPath = join(publicRoot, pathname);
 		try {
-			// トランスパイルして結果のコードを得る
-			const { code } = await bundle(tsPath, {
-				importMap: denoConfig,
+			const result = await esbuild.build({
+				entryPoints: [tsPath],
+				plugins: [denoPlugin()],
+				bundle: true,
+				write: false,
+				format: 'esm',
 			});
 
-			// トランスパイルした結果のコードを返す
-			// Determine cache duration based on environment
+			const code = result.outputFiles[0].text;
+
+			// 環境に応じてキャッシュの有効期限を設定する
 			const env = Deno.env.get('DENO_ENV') || 'development';
-			const cacheControl =
-				env === 'production'
-					? 'public, max-age=31536000, immutable'
-					: 'no-cache, no-store, must-revalidate';
+			const cacheControl = env === 'production'
+				? 'public, max-age=31536000, immutable'
+				: 'no-cache, no-store, must-revalidate';
+
 			return new Response(code, {
 				headers: {
 					'Content-Type': 'application/javascript; charset=utf-8',
 					'Cache-Control': cacheControl,
 				},
 			});
-		} catch (error) { // トランスパイル時にエラーが発生した際
-			const errorMessage = error && error.message ? error.message : String(error);
-			return new Response(
-				`TypeScript bundling error: ${errorMessage}`,
-				{ status: 500 }
-			);
+		} catch (error) {
+			const errorMessage = error && (error as Error).message 
+				? (error as Error).message
+				: String(error);
+			console.error('esbuild build error:', error);
+			return new Response(`TypeScript bundling error: ${errorMessage}`, {
+				status: 500,
+			});
 		}
 	}
-    
+
 	if (req.method === 'GET' && pathname === '/welcome-message') {
 		return new Response('jigインターンへようこそ！');
 	}

--- a/test/issue12/index.html
+++ b/test/issue12/index.html
@@ -1,0 +1,32 @@
+<!--https://github.com/code4fukui/egmapjs/blob/master/map2.html-->
+<!DOCTYPE html><html lang="ja"><head><meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width"/>
+
+    <title>マップアプリ2</title>
+
+    <link rel="apple-touch-icon" href="app-icon.png"/>
+    <meta property="og:image" content="ogp-image.jpg"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css"/>
+    
+    <link rel="stylesheet" href="https://code4fukui.github.io/egmapjs/egmap.css"/>
+    <script src="https://fukuno.jig.jp/fukuno.js"></script>
+    <script src="https://code4fukui.github.io/egmapjs/sparql.js"></script>
+    
+    
+    <style>
+
+        body { margin: 0; font-family: sans-serif; text-align: center; }
+        h1 { font-size: 5vw; margin: 0; }
+        #mapid { height: 60vh; }
+
+    </style></head><body>
+
+<h1>マップアプリ2</h1>
+<div id="mapid"></div>
+
+<img id=qrcode><script>addEventListener("load", () => qrcode.src = "https://chart.apis.google.com/chart?chs=140x140&cht=qr&chl=" + encodeURIComponent(document.location))</script><br>
+
+<a href=https://fukuno.jig.jp/2393>簡単地図アプリ egmapjs チュートリアル</a>
+
+<script src="index.ts" type="module"></script>
+</body></html>

--- a/test/issue12/index.ts
+++ b/test/issue12/index.ts
@@ -1,0 +1,31 @@
+import {initMap} from "egmap";
+import L from 'leaflet';
+
+const map = initMap('mapid')
+map.setZoom(16)
+map.panTo([ 35.943560,136.188917 ]) // 鯖江駅
+// スラッシュ2つ続けると「コメント」になる、後ろの行は何を書いてもプログラムに影響なし
+
+// ピンを追加
+map.addIcon(35.943560,136.188917, "鯖江駅")
+
+// アイコンを追加
+map.addIcon(35.944571, 136.186228 , "Hana道場", "icon/hanadojo.png", 64)
+
+// タップしたところの緯度経度を表示
+map.on("click", (e) => alert(e.latlng))
+
+// 線分を地図上に表示する
+map.addLayer(L.polyline([
+    [ 35.94, 136.18 ],
+    [ 35.95, 136.19 ],
+    [ 35.94, 136.20 ]
+], { color: 'red' }))
+
+// 領域を地図上に表示する
+map.addLayer(L.polygon([
+    [ 35.941, 136.189 ],
+    [ 35.942, 136.190 ],
+    [ 35.941, 136.191 ]
+], { color: 'green' }))
+


### PR DESCRIPTION
## 概要

フロントのtsをバンドルするライブラリの一つ、deno_emitはnpmライブラリ非対応だったためesbuildに移行しました。
レビュー工数削減のため、"feature/#12-egmapjsTS化"を本ブランチにrebaseしています。そのためTS化も


## 関連
#12 
#13 

## テスト方法

1. /test/issue12を/public内にコピーする (-> /public/issue12 となる) 
2. "http://localhost:8000/issue12"にアクセス
3. 地図が正常に表示されることを確認する 
(-> egmapのTS化とTSの変換の両方ができていることになる)

## レビュアーチェックリスト

- [x] /test/issue12を/public内にコピー (-> /public/issue12 となる) し, "http://localhost:8000/issue12" で地図が正常に表示されることを確認する.
