### PR TITLE
#46 longitude

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: Deploy
 on:
   push:
-    branches: main
+    branches: #46-longitude
   pull_request:
-    branches: main
+    branches: #46-longitude
 
 jobs:
   deploy:
@@ -24,12 +24,12 @@ jobs:
           deno-version: v2.x
 
       - name: Build step
-        run: "deno bundle --platform=browser public/main.ts -o public/main.js"
+        run: "deno bundle --platform=browser --minify public/main.ts -o public/main.js"
 
       - name: Upload to Deno Deploy
         uses: denoland/deployctl@v1
         with:
-          project: "2025-summer-13"
+          project: "kotaoka-2025-summer-63"
           entrypoint: "main.ts"
           root: ""
           

--- a/public/map-initializer.ts
+++ b/public/map-initializer.ts
@@ -31,6 +31,7 @@ export function initMap(mapid: string, onShapeCreated: (layer: LeafletLayer) => 
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     maxNativeZoom: 19,
     maxZoom: 22,
+    minZoom: 5,
   }).addTo(map);
 
   /** マーカーや情報ボックスを保持するための専用レイヤーグループ。 */

--- a/public/map.ts
+++ b/public/map.ts
@@ -129,6 +129,14 @@ async function handleShapeCreated(layer: LeafletLayer): Promise<boolean> {
 // ================== 初期化処理 ==================
 /** Leafletマップのインスタンス。 */
 export const map: LeafletMap = initMap("map", handleShapeCreated);
+
+// マップの移動範囲を全世界に制限
+const worldBounds = L.latLngBounds(
+    L.latLng(-90, -180), // 南西の角
+    L.latLng(90, 180)    // 北東の角
+);
+map.setMaxBounds(worldBounds);
+
 map.setView([35.943, 136.188], 15);
 
 // 初期データを一度だけ、全範囲で読み込む
@@ -138,6 +146,7 @@ loadAndRenderData();
 const drawRectangleButton = document.getElementById('draw-rectangle') as HTMLButtonElement;
 const drawPolygonButton = document.getElementById('draw-polygon') as HTMLButtonElement;
 const drawCircleButton = document.getElementById('draw-circle') as HTMLButtonElement;
+
 
 const rectangleDrawer = new L.Draw.Rectangle(map);
 const polygonDrawer = new L.Draw.Polygon(map);

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,5 +1,6 @@
 import type { PostSubmission, QueryParams } from '../types/postData.ts';
 const BASE_URL = 'http://localhost:8000'; // For local testing. Change for production.
+//const BASE_URL = window.location.origin;
 
 export const postJson = async (data: PostSubmission): Promise<Response> => {
     const endpoint = `${BASE_URL}/post-json`;


### PR DESCRIPTION
## 概要

移動できる軽度の範囲を-180~180に設定し、マップの縮小サイズの限界値を設定

localhostからlocation.originに変更

## 関連

#46 #76 

## テスト方法

画面を左右に動かして、マップの限界値以上へ移動できないか確認


## レビュアーチェックリスト

- [ ] 画面を左右に動かして、マップの限界値以上へ移動できないか
- [ ] マップを縮小しても縮小しすぎない
- [ ] 正常に動作するか(POST)
