### PR TITLE
[add] cssでコメントのdisplayをnoneに設定

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -30,6 +30,15 @@
     border: 1px solid #777;
     z-index: 500;
     position: relative;
+
+
+}
+
+/* 非表示にするためのクラス */
+.info-hidden {
+    display: none;
+    /* opacity: 0; */ /* display: noneの代わり。アニメーションさせたい場合はこちら */
+    /* pointer-events: none; */ /* opacityとセットで使う */
 }
 
 .hide-tooltips .leaflet-tooltip.info-tooltip {


### PR DESCRIPTION
## 概要

マップを縮小した時にコメントが表示されないようにする

## 関連

#88 

## テスト方法

マップを縮小する
