### PR TITLE
[update] アプリ名をおもかげ地図に変更

### DIFF
--- a/public/components/header-component.ts
+++ b/public/components/header-component.ts
@@ -23,8 +23,7 @@ const content: string = `
     }
     </style>
     <header>
-    
-        思い出マップ(仮)
+    おもかげ地図
     </header>
    
       `;

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <title>思い出マップ(仮)</title>
+    <title>おもかげ地図</title>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## 概要

アプリ名を「おもかげ地図」に変更しました。
タブに表示されるtitleとヘッダーのタイトルを変更しました。

## 関連

#100


## テスト方法

pullして表示してタブ名とヘッダーが変わっていることを確認する。

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
