### PR TITLE
地理院地図を使うように変更

### DIFF
--- a/lib/egmap.ts
+++ b/lib/egmap.ts
@@ -45,10 +45,17 @@ export interface MapWithIconLayer extends L.Map {
 export const initMap = (mapid: string): MapWithIconLayer => {
     const map = L.map(mapid) as MapWithIconLayer; // 指定されたIDの要素にLeafletマップオブジェクトを生成
 
+    const layer = "https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png";
+    const attribution = '<a href="https://maps.gsi.go.jp/development/ichiran.html">国土地理院</a>';
+    const maxNativeZoom = 18;
+
     // OpenStreetMapから地図タイルを取得し、マップレイヤーとして追加
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	L.tileLayer(layer, {
         // 地図の著作権情報を設定します
-        attribution: '© <a href="http://osm.org/copyright">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+        attribution,
+        maxNativeZoom,
+        maxZoom: 22,
+        minZoom: 5,
     }).addTo(map); // 作成したタイルレイヤーをマップに追加
 
     // アイコン関連の初期設定

--- a/public/map-initializer.ts
+++ b/public/map-initializer.ts
@@ -43,9 +43,13 @@ export function initMap(mapid: string, onShapeCreated: (layer: LeafletLayer) => 
 		center: [35.943, 136.188]
 	});
 
-	L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-    maxNativeZoom: 19,
+  const layer = "https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png";
+  const attribution = '<a href="https://maps.gsi.go.jp/development/ichiran.html">国土地理院</a>';
+  const maxNativeZoom = 18;
+
+	L.tileLayer(layer, {
+    attribution,
+    maxNativeZoom,
     maxZoom: 22,
     minZoom: 5,
   }).addTo(map);


### PR DESCRIPTION
地理院地図は利用可能（詳細地図は日本のみ）

オープンストリートマップのタイルサーバーは本番運用不可（アドレスのハードコーディング不推奨）

https://community.openstreetmap.org/t/should-osmf-offer-free-raster-tiles-for-end-users-not-for-osm-map-qa/113505/20?page=2&utm_source=chatgpt.com

## 概要

タイルサーバーのアドレスとズーム範囲設定変更

## 関連

https://github.com/jigintern/2025-summer-c/issues/104

## テスト方法

表示と、ズームを確認

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
