### PR TITLE
compile taskを追加

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,15 @@
     "lit": "npm:lit@^3.3.1"
   },
   "tasks": {
-    "start": "deno bundle --platform=browser --minify public/main.ts -o public/main.js && deno run --watch --allow-net --allow-read --allow-write --allow-run --allow-env --unstable-kv main.ts"
+    "compile" : {
+      "command": "deno bundle --platform=browser --minify public/main.ts -o public/main.js",
+      "description": "tsをjsにコンパイルする"
+    },
+    "start": {
+      "command": "deno run --watch --allow-net --allow-read --allow-write --allow-run --allow-env --unstable-kv main.ts",
+      "dependencies": ["compile"],
+      "description": "アプリケーションを実行する"
+    }
   },
   "compilerOptions": {
     "lib": [


### PR DESCRIPTION
## 概要
deno.jsonのtaskには2.1から、タスク同士の依存が実装されており（ https://deno.com/blog/v2.1#task-dependencies ）、依存している処理が並列で実行できるなら一つのtaskで複数のコマンドを`&&`でつなぐよりもきれいそうなので変更した。

## 関連
#107 

## テスト方法
- ローカル環境の`public/main.js`を削除し、`deno task compile`を実行した場合に、`public/main.js`が生成される
- ローカル環境の`public/main.js`を削除し、`deno task start`を実行した場合に、`public/main.js`が生成されたのち、アプリが正常に動作する。

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
